### PR TITLE
Bugfix in to_catalog

### DIFF
--- a/dendrocat/radiosource.py
+++ b/dendrocat/radiosource.py
@@ -197,8 +197,10 @@ class RadioSource:
                 dendrogram = self.to_dendrogram()
 
         cat = pp_catalog(dendrogram.leaves, self.metadata)
-        cat.add_column(Column(length=len(cat), shape=20, dtype=str),
-                       name='_name')
+        strarr=[]
+        for idx in cat['_idx']:
+            strarr.append(str('{:.0f}{:04d}'.format(np.round(self.nu.to(u.GHz).value), idx)))  
+        cat.add_column(Column(data=strarr),name='_name') 
         cat.add_column(Column(data=range(len(cat))), name='_index')
         cat = cat[sorted(cat.colnames)]
 

--- a/dendrocat/radiosource.py
+++ b/dendrocat/radiosource.py
@@ -204,10 +204,6 @@ class RadioSource:
         cat.add_column(Column(data=range(len(cat))), name='_index')
         cat = cat[sorted(cat.colnames)]
 
-        for i, idx in enumerate(cat['_idx']):
-            cat['_name'][i] = str('{:.0f}{:03d}'.format(
-                                       np.round(self.nu.to(u.GHz).value), idx))
-
         try:
             cat['major_sigma'] = cat['major_sigma']*np.sqrt(8*np.log(2))
             cat['minor_sigma'] = cat['minor_sigma']*np.sqrt(8*np.log(2))

--- a/dendrocat/radiosource.py
+++ b/dendrocat/radiosource.py
@@ -198,7 +198,7 @@ class RadioSource:
 
         cat = pp_catalog(dendrogram.leaves, self.metadata)
         strarr=[str('{:.0f}{:04d}'.format(np.round(self.nu.to(u.GHz).value), idx)) for idx in cat['_idx']]  
-        cat.add_column(Column(data=strarr),name='_name') 
+        cat.add_column(Column(data=strarr), name='_name')
         cat.add_column(Column(data=range(len(cat))), name='_index')
         cat = cat[sorted(cat.colnames)]
 

--- a/dendrocat/radiosource.py
+++ b/dendrocat/radiosource.py
@@ -197,9 +197,7 @@ class RadioSource:
                 dendrogram = self.to_dendrogram()
 
         cat = pp_catalog(dendrogram.leaves, self.metadata)
-        strarr=[]
-        for idx in cat['_idx']:
-            strarr.append(str('{:.0f}{:04d}'.format(np.round(self.nu.to(u.GHz).value), idx)))  
+        strarr=[str('{:.0f}{:04d}'.format(np.round(self.nu.to(u.GHz).value), idx)) for idx in cat['_idx']]  
         cat.add_column(Column(data=strarr),name='_name') 
         cat.add_column(Column(data=range(len(cat))), name='_index')
         cat = cat[sorted(cat.colnames)]


### PR DESCRIPTION
When I try to run to_catalog function, there was an error in cat.add_column(Column(length=len(cat), shape=20, dtype=str), name='_name'). The first problem was 'shape=20' because the shape argument is the dimension of the row element in the column. It should be a scalar so I deleted it. The second problem was that when you make a column without data argument the string datatype is always fixed to 'str1' meaning you can store only one string. The better way to solve this is to make a list of strings first and then add it to a column. After I fixed it, it worked!
